### PR TITLE
	Allows singleton_methods to be registered

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ end
 Also if you want to add more than one method in the same class and customize the circuit name:
 
 ```ruby
-class Foo4
+class MyFooService
   include Protoboard::CircuitBreaker
 
   register_circuits({ some_method: 'my_custom_name', other_method: 'my_other_custom_name' },
@@ -77,6 +77,30 @@ class Foo4
     })
   def some_method
     'OK'
+  end
+end
+```
+
+And you can add singleton methods to be wrapped by a circuit:
+
+```ruby
+class MyFooService
+  include Protoboard::CircuitBreaker
+
+  register_circuits [:some_method, :some_singleton_method],
+    singleton_methods: [:some_singleton_method],
+    options: {
+      service: 'my_cool_service',
+      open_after: 2,
+      cool_off_after: 3
+    }
+
+  def self.some_singleton_method
+    # Something that can break
+  end
+
+  def some_method
+    # Something that can break
   end
 end
 ```

--- a/lib/protoboard/circuit.rb
+++ b/lib/protoboard/circuit.rb
@@ -20,8 +20,13 @@ module Protoboard
       @fallback = options[:fallback]
       @on_before = options.fetch(:on_before, [])
       @on_after = options.fetch(:on_after, [])
+      @singleton_method = options.fetch(:singleton_method, false)
     rescue KeyError => error
       raise ArgumentError, "Missing required arguments: #{error.message}"
+    end
+
+    def singleton_method?
+      @singleton_method
     end
   end
 end

--- a/lib/protoboard/circuit_breaker.rb
+++ b/lib/protoboard/circuit_breaker.rb
@@ -103,10 +103,10 @@ module Protoboard
         circuit_hash.map do |circuit_method, circuit_name|
           Circuit.new({
             name: circuit_name,
-            method_name: circuit_method
+            method_name: circuit_method,
+            singleton_method: singleton_methods.include?(circuit_method.to_sym)
           }
-          .merge(options)
-          .merge(singleton_method: singleton_methods.include?(circuit_method.to_sym)))
+          .merge(options))
         end
       end
 

--- a/lib/protoboard/circuit_proxy_factory.rb
+++ b/lib/protoboard/circuit_proxy_factory.rb
@@ -12,12 +12,34 @@ module Protoboard
         module_name = infer_module_name(class_name, circuits.map(&:method_name))
         proxy_module = Module.new
 
+        # Encapsulates instance methods in a module to be used later
         proxy_module.instance_exec do
-          circuits.each do |circuit|
-            define_method(circuit.method_name) do |*args|
-              Protoboard.config.adapter.run_circuit(circuit) { super(*args) }
+          instance_methods = Module.new do
+            circuits.each do |circuit|
+              unless circuit.singleton_method?
+                define_method(circuit.method_name) do |*args|
+                  Protoboard.config.adapter.run_circuit(circuit) { super(*args) }
+                end
+              end
             end
           end
+
+          proxy_module.const_set('InstanceMethods', instance_methods)
+        end
+
+        # Encapsulates singleton methods in a module to be used later
+        proxy_module.instance_exec do
+          class_methods = Module.new do
+            circuits.each do |circuit|
+              if circuit.singleton_method?
+                define_method(circuit.method_name) do |*args|
+                  Protoboard.config.adapter.run_circuit(circuit) { super(*args) }
+                end
+              end
+            end
+          end
+
+          proxy_module.const_set('ClassMethods', class_methods)
         end
 
         Protoboard.const_set(module_name, proxy_module)

--- a/lib/protoboard/circuit_proxy_factory.rb
+++ b/lib/protoboard/circuit_proxy_factory.rb
@@ -13,34 +13,30 @@ module Protoboard
         proxy_module = Module.new
 
         # Encapsulates instance methods in a module to be used later
-        proxy_module.instance_exec do
-          instance_methods = Module.new do
-            circuits.each do |circuit|
-              unless circuit.singleton_method?
-                define_method(circuit.method_name) do |*args|
-                  Protoboard.config.adapter.run_circuit(circuit) { super(*args) }
-                end
+        instance_methods = Module.new do
+          circuits.each do |circuit|
+            unless circuit.singleton_method?
+              define_method(circuit.method_name) do |*args|
+                Protoboard.config.adapter.run_circuit(circuit) { super(*args) }
               end
             end
           end
-
-          proxy_module.const_set('InstanceMethods', instance_methods)
         end
+
+        proxy_module.const_set('InstanceMethods', instance_methods)
 
         # Encapsulates singleton methods in a module to be used later
-        proxy_module.instance_exec do
-          class_methods = Module.new do
-            circuits.each do |circuit|
-              if circuit.singleton_method?
-                define_method(circuit.method_name) do |*args|
-                  Protoboard.config.adapter.run_circuit(circuit) { super(*args) }
-                end
+        class_methods = Module.new do
+          circuits.each do |circuit|
+            if circuit.singleton_method?
+              define_method(circuit.method_name) do |*args|
+                Protoboard.config.adapter.run_circuit(circuit) { super(*args) }
               end
             end
           end
-
-          proxy_module.const_set('ClassMethods', class_methods)
         end
+
+        proxy_module.const_set('ClassMethods', class_methods)
 
         Protoboard.const_set(module_name, proxy_module)
       end


### PR DESCRIPTION
	* Separates the proxy modules in two when registering the circuits: InstanceMethods (containing instance methods) and ClassMethods (containing singleton methods)
	* Prepends the ClassMethods module to the singleton class of the registering circuit class
	* Includes tests