### PR TITLE
[FIX] Converting method name's special chars to ordinals with 'ORD' prefix

### DIFF
--- a/lib/protoboard/circuit_proxy_factory.rb
+++ b/lib/protoboard/circuit_proxy_factory.rb
@@ -46,16 +46,17 @@ module Protoboard
       ##
       # Formats the module name
       def infer_module_name(class_name, methods)
-        class_name_ = "#{class_name.split('::').join('')}"
         methods = methods.map(&:to_s).map { |method| convert_special_chars_to_ordinals(method) }
-        "#{methods.map { |method| method.camelize }.join}#{class_name_}CircuitProxy"
+        "#{methods.map { |method| method.camelize }.join}#{class_name.split('::').join('')}CircuitProxy"
       end
 
       def convert_special_chars_to_ordinals(method)
         special_chars = method.scan(/\W/i)
         return method if special_chars.empty?
 
-        special_chars.uniq.each { |special_char| method = method.gsub(special_char.to_s, "ORD#{special_char.to_s.ord}") }
+        special_chars.uniq.each do |special_char|
+          method = method.gsub(special_char.to_s, "ORD#{special_char.to_s.ord}")
+        end
         method
       end
     end

--- a/lib/protoboard/circuit_proxy_factory.rb
+++ b/lib/protoboard/circuit_proxy_factory.rb
@@ -46,18 +46,11 @@ module Protoboard
       ##
       # Formats the module name
       def infer_module_name(class_name, methods)
-        methods = methods.map(&:to_s).map { |method| convert_special_chars_to_ordinals(method) }
-        "#{methods.map(&:camelize).join}#{class_name.split('::').join('')}CircuitProxy"
-      end
-
-      def convert_special_chars_to_ordinals(method)
-        special_chars = method.scan(/\W/i)
-        return method if special_chars.empty?
-
-        special_chars.uniq.each do |special_char|
-          method = method.gsub(special_char, "ORD#{special_char.ord}")
+        methods = methods.map(&:to_s).map do |method|
+          method.convert_special_chars_to_ordinals
         end
-        method
+        methods_joined = methods.map { |method| method.camelize }.join
+        "#{methods_joined}#{class_name.split('::').join('')}CircuitProxy"
       end
     end
   end

--- a/lib/protoboard/circuit_proxy_factory.rb
+++ b/lib/protoboard/circuit_proxy_factory.rb
@@ -47,7 +47,7 @@ module Protoboard
       # Formats the module name
       def infer_module_name(class_name, methods)
         methods = methods.map(&:to_s).map { |method| convert_special_chars_to_ordinals(method) }
-        "#{methods.map { |method| method.camelize }.join}#{class_name.split('::').join('')}CircuitProxy"
+        "#{methods.map(&:camelize).join}#{class_name.split('::').join('')}CircuitProxy"
       end
 
       def convert_special_chars_to_ordinals(method)
@@ -55,7 +55,7 @@ module Protoboard
         return method if special_chars.empty?
 
         special_chars.uniq.each do |special_char|
-          method = method.gsub(special_char.to_s, "ORD#{special_char.to_s.ord}")
+          method = method.gsub(special_char, "ORD#{special_char.ord}")
         end
         method
       end

--- a/lib/protoboard/circuit_proxy_factory.rb
+++ b/lib/protoboard/circuit_proxy_factory.rb
@@ -46,7 +46,17 @@ module Protoboard
       ##
       # Formats the module name
       def infer_module_name(class_name, methods)
-        "#{methods.map(&:to_s).map { |method| method.camelize }.join}#{class_name.split('::').join('')}CircuitProxy"
+        class_name_ = "#{class_name.split('::').join('')}"
+        methods = methods.map(&:to_s).map { |method| convert_special_chars_to_ordinals(method) }
+        "#{methods.map { |method| method.camelize }.join}#{class_name_}CircuitProxy"
+      end
+
+      def convert_special_chars_to_ordinals(method)
+        special_chars = method.scan(/\W/i)
+        return method if special_chars.empty?
+
+        special_chars.uniq.each { |special_char| method = method.gsub(special_char.to_s, "ORD#{special_char.to_s.ord}") }
+        method
       end
     end
   end

--- a/lib/protoboard/refinements/string_extensions.rb
+++ b/lib/protoboard/refinements/string_extensions.rb
@@ -6,6 +6,18 @@ module Protoboard
           string = sub(/^[a-z\d]*/) { $&.capitalize }
           string.gsub(/(?:_|(\/))([a-z\d]*)/) { "#{$1}#{$2.capitalize}" }.gsub('/', '::')
         end
+
+        def convert_special_chars_to_ordinals(prefix='ORD')
+          special_chars = self.scan(/\W/i)
+          return self if special_chars.empty?
+          
+          new_string = self
+          special_chars.uniq.each do |special_char|
+            new_char = "#{prefix}#{special_char.ord}"
+            new_string = new_string.gsub(special_char, new_char)
+          end
+          new_string
+        end
       end
     end
   end

--- a/lib/protoboard/refinements/string_extensions.rb
+++ b/lib/protoboard/refinements/string_extensions.rb
@@ -7,10 +7,10 @@ module Protoboard
           string.gsub(/(?:_|(\/))([a-z\d]*)/) { "#{$1}#{$2.capitalize}" }.gsub('/', '::')
         end
 
-        def convert_special_chars_to_ordinals(prefix='ORD')
+        def convert_special_chars_to_ordinals(prefix = 'ORD')
           special_chars = self.scan(/\W/i)
           return self if special_chars.empty?
-          
+
           new_string = self
           special_chars.uniq.each do |special_char|
             new_char = "#{prefix}#{special_char.ord}"

--- a/spec/lib/protoboard/circuit_proxy_factory_spec.rb
+++ b/spec/lib/protoboard/circuit_proxy_factory_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe Protoboard::CircuitProxyFactory do
       it 'returns a module proxying the methods' do
         is_expected.to eq(Protoboard::SomeMethodSomeMethod2FooBarCircuitProxy)
 
-        expect(subject.const_get('InstanceMethods').instance_methods).to include(:some_method, :some_method2)
+        expect(subject.const_get('InstanceMethods').instance_methods)
+          .to include(:some_method, :some_method2)
       end
     end
 
@@ -53,7 +54,8 @@ RSpec.describe Protoboard::CircuitProxyFactory do
       it 'returns a module proxying the methods' do
         is_expected.to eq(Protoboard::SomeMethodORD33SomeMethod2FooBarCircuitProxy)
 
-        expect(subject.const_get('InstanceMethods').instance_methods).to include(:some_method!, :some_method2)
+        expect(subject.const_get('InstanceMethods').instance_methods)
+          .to include(:some_method!, :some_method2)
       end
     end
 
@@ -70,7 +72,8 @@ RSpec.describe Protoboard::CircuitProxyFactory do
       it 'returns a module proxying the methods' do
         is_expected.to eq(Protoboard::SomeMethodORD61SomeMethod2FooBarCircuitProxy)
 
-        expect(subject.const_get('InstanceMethods').instance_methods).to include(:some_method=, :some_method2)
+        expect(subject.const_get('InstanceMethods').instance_methods)
+          .to include(:some_method=, :some_method2)
       end
     end
 
@@ -87,7 +90,8 @@ RSpec.describe Protoboard::CircuitProxyFactory do
       it 'returns a module proxying the methods' do
         is_expected.to eq(Protoboard::ORD61ORD61SomeMethod2FooBarCircuitProxy)
 
-        expect(subject.const_get('InstanceMethods').instance_methods).to include(:==, :some_method2)
+        expect(subject.const_get('InstanceMethods').instance_methods)
+          .to include(:==, :some_method2)
       end
     end
 
@@ -104,7 +108,8 @@ RSpec.describe Protoboard::CircuitProxyFactory do
       it 'returns a module proxying the methods' do
         is_expected.to eq(Protoboard::ORD60ORD61ORD62SomeMethod2FooBarCircuitProxy)
 
-        expect(subject.const_get('InstanceMethods').instance_methods).to include(:<=>, :some_method2)
+        expect(subject.const_get('InstanceMethods').instance_methods)
+          .to include(:<=>, :some_method2)
       end
     end
 
@@ -114,12 +119,14 @@ RSpec.describe Protoboard::CircuitProxyFactory do
       it 'returns a module proxying the methods' do
         is_expected.to eq(Protoboard::SomeMethodSomeMethod2FooBarCircuitProxy)
 
-        expect(subject::InstanceMethods.instance_methods).to include(:some_method, :some_method2)
+        expect(subject::InstanceMethods.instance_methods)
+          .to include(:some_method, :some_method2)
       end
     end
 
     it 'defines a proxy for the given methods' do
-      expect(Protoboard::Adapters::StoplightAdapter).to receive(:run_circuit).once
+      expect(Protoboard::Adapters::StoplightAdapter)
+        .to receive(:run_circuit).once
 
       create_module
 
@@ -144,7 +151,8 @@ RSpec.describe Protoboard::CircuitProxyFactory do
       end
 
       it 'defines a proxy for the given methods' do
-        expect(Protoboard::Adapters::StoplightAdapter).to receive(:run_circuit).once
+        expect(Protoboard::Adapters::StoplightAdapter)
+          .to receive(:run_circuit).once
 
         create_module
 

--- a/spec/lib/protoboard/circuit_proxy_factory_spec.rb
+++ b/spec/lib/protoboard/circuit_proxy_factory_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Protoboard::CircuitProxyFactory do
       end
     end
 
-    context 'with a method name containing a bang caracter' do
+    context 'with a method name containing a bang character' do
       let(:circuit1) do
         Protoboard::Circuit.new(
           name: 'my_cool_service#some_method!',
@@ -59,7 +59,7 @@ RSpec.describe Protoboard::CircuitProxyFactory do
       end
     end
 
-    context 'with a method name containing a equal caracter' do
+    context 'with a method name containing a equal character' do
       let(:circuit1) do
         Protoboard::Circuit.new(
           name: 'my_cool_service#some_method=',
@@ -110,6 +110,24 @@ RSpec.describe Protoboard::CircuitProxyFactory do
 
         expect(subject.const_get('InstanceMethods').instance_methods)
           .to include(:<=>, :some_method2)
+      end
+    end
+
+    context 'with a method name containing a question mark character' do
+      let(:circuit1) do
+        Protoboard::Circuit.new(
+          name: 'my_cool_service#some_method?',
+          service: 'my_cool_service',
+          method_name: 'some_method?',
+          open_after: 2,
+          cool_off_after: 3
+        )
+      end
+      it 'returns a module proxying the methods' do
+        is_expected.to eq(Protoboard::SomeMethodORD63SomeMethod2FooBarCircuitProxy)
+
+        expect(subject.const_get('InstanceMethods').instance_methods)
+          .to include(:some_method?, :some_method2)
       end
     end
 

--- a/spec/lib/protoboard/circuit_proxy_factory_spec.rb
+++ b/spec/lib/protoboard/circuit_proxy_factory_spec.rb
@@ -40,6 +40,74 @@ RSpec.describe Protoboard::CircuitProxyFactory do
       end
     end
 
+    context 'with a method name containing a bang caracter' do
+      let(:circuit1) do
+        Protoboard::Circuit.new(
+          name: 'my_cool_service#some_method!',
+          service: 'my_cool_service',
+          method_name: 'some_method!',
+          open_after: 2,
+          cool_off_after: 3
+        )
+      end
+      it 'returns a module proxying the methods' do
+        is_expected.to eq(Protoboard::SomeMethodORD33SomeMethod2FooBarCircuitProxy)
+
+        expect(subject.const_get('InstanceMethods').instance_methods).to include(:some_method!, :some_method2)
+      end
+    end
+
+    context 'with a method name containing a equal caracter' do
+      let(:circuit1) do
+        Protoboard::Circuit.new(
+          name: 'my_cool_service#some_method=',
+          service: 'my_cool_service',
+          method_name: 'some_method=',
+          open_after: 2,
+          cool_off_after: 3
+        )
+      end
+      it 'returns a module proxying the methods' do
+        is_expected.to eq(Protoboard::SomeMethodORD61SomeMethod2FooBarCircuitProxy)
+
+        expect(subject.const_get('InstanceMethods').instance_methods).to include(:some_method=, :some_method2)
+      end
+    end
+
+    context 'with a method name like a double equal' do
+      let(:circuit1) do
+        Protoboard::Circuit.new(
+          name: 'my_cool_service#==',
+          service: 'my_cool_service',
+          method_name: '==',
+          open_after: 2,
+          cool_off_after: 3
+        )
+      end
+      it 'returns a module proxying the methods' do
+        is_expected.to eq(Protoboard::ORD61ORD61SomeMethod2FooBarCircuitProxy)
+
+        expect(subject.const_get('InstanceMethods').instance_methods).to include(:==, :some_method2)
+      end
+    end
+
+    context 'with a method name like a spaceship operator' do
+      let(:circuit1) do
+        Protoboard::Circuit.new(
+          name: 'my_cool_service#<=>',
+          service: 'my_cool_service',
+          method_name: '<=>',
+          open_after: 2,
+          cool_off_after: 3
+        )
+      end
+      it 'returns a module proxying the methods' do
+        is_expected.to eq(Protoboard::ORD60ORD61ORD62SomeMethod2FooBarCircuitProxy)
+
+        expect(subject.const_get('InstanceMethods').instance_methods).to include(:<=>, :some_method2)
+      end
+    end
+
     context 'with a class name containing namespace' do
       let(:class_name) { 'Foo::Bar' }
 

--- a/spec/lib/protoboard/refinements/string_extensions_spec.rb
+++ b/spec/lib/protoboard/refinements/string_extensions_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe 'Protoboard::Refinements::StringExtensions' do
   using Protoboard::Refinements::StringExtensions
 
-  describe '.convert_special_chars_to_ordinals' do
+  describe '#convert_special_chars_to_ordinals' do
     subject { some_string.convert_special_chars_to_ordinals }
 
     context 'when a string contains letters and numbers only' do
@@ -17,7 +17,7 @@ RSpec.describe 'Protoboard::Refinements::StringExtensions' do
     context 'when a string contains letters, numbers and a bang' do
       let(:some_string) { 'abc123!' }
 
-      it 'returns the a new value with no bang' do
+      it 'returns the new value with no bang' do
         is_expected.to eq('abc123ORD33')
       end
     end
@@ -25,7 +25,7 @@ RSpec.describe 'Protoboard::Refinements::StringExtensions' do
     context 'when a string contains letters, numbers and a equal signal' do
       let(:some_string) { 'abc123=' }
 
-      it 'returns the a new value with no equal' do
+      it 'returns the new value with no equal' do
         is_expected.to eq('abc123ORD61')
       end
     end
@@ -33,7 +33,7 @@ RSpec.describe 'Protoboard::Refinements::StringExtensions' do
     context 'when a string contains a double equal signals' do
       let(:some_string) { '==' }
 
-      it 'returns the a new value with no equal' do
+      it 'returns the new value with no equal' do
         is_expected.to eq('ORD61ORD61')
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe 'Protoboard::Refinements::StringExtensions' do
     context 'when a string contains a spaceship operator' do
       let(:some_string) { '<=>' }
 
-      it 'returns the a new value with no nave spaceship' do
+      it 'returns the new value with no spaceship operator' do
         is_expected.to eq('ORD60ORD61ORD62')
       end
     end

--- a/spec/lib/protoboard/refinements/string_extensions_spec.rb
+++ b/spec/lib/protoboard/refinements/string_extensions_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Protoboard::Refinements::StringExtensions' do
     subject { some_string.convert_special_chars_to_ordinals }
 
     context 'when a string contains letters and numbers only' do
-      let(:some_string) { "abc123" }
+      let(:some_string) { 'abc123' }
 
       it 'returns the same value' do
         is_expected.to eq(some_string)
@@ -15,7 +15,7 @@ RSpec.describe 'Protoboard::Refinements::StringExtensions' do
     end
 
     context 'when a string contains letters, numbers and a bang' do
-      let(:some_string) { "abc123!" }
+      let(:some_string) { 'abc123!' }
 
       it 'returns the a new value with no bang' do
         is_expected.to eq('abc123ORD33')
@@ -23,7 +23,7 @@ RSpec.describe 'Protoboard::Refinements::StringExtensions' do
     end
 
     context 'when a string contains letters, numbers and a equal signal' do
-      let(:some_string) { "abc123=" }
+      let(:some_string) { 'abc123=' }
 
       it 'returns the a new value with no equal' do
         is_expected.to eq('abc123ORD61')
@@ -31,7 +31,7 @@ RSpec.describe 'Protoboard::Refinements::StringExtensions' do
     end
 
     context 'when a string contains a double equal signals' do
-      let(:some_string) { "==" }
+      let(:some_string) { '==' }
 
       it 'returns the a new value with no equal' do
         is_expected.to eq('ORD61ORD61')
@@ -39,7 +39,7 @@ RSpec.describe 'Protoboard::Refinements::StringExtensions' do
     end
 
     context 'when a string contains a spaceship operator' do
-      let(:some_string) { "<=>" }
+      let(:some_string) { '<=>' }
 
       it 'returns the a new value with no nave spaceship' do
         is_expected.to eq('ORD60ORD61ORD62')

--- a/spec/lib/protoboard/refinements/string_extensions_spec.rb
+++ b/spec/lib/protoboard/refinements/string_extensions_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Protoboard::Refinements::StringExtensions' do
+  using Protoboard::Refinements::StringExtensions
+
+  describe '.convert_special_chars_to_ordinals' do
+    subject { some_string.convert_special_chars_to_ordinals }
+
+    context 'when a string contains letters and numbers only' do
+      let(:some_string) { "abc123" }
+
+      it 'returns the same value' do
+        is_expected.to eq(some_string)
+      end
+    end
+
+    context 'when a string contains letters, numbers and a bang' do
+      let(:some_string) { "abc123!" }
+
+      it 'returns the a new value with no bang' do
+        is_expected.to eq('abc123ORD33')
+      end
+    end
+
+    context 'when a string contains letters, numbers and a equal signal' do
+      let(:some_string) { "abc123=" }
+
+      it 'returns the a new value with no equal' do
+        is_expected.to eq('abc123ORD61')
+      end
+    end
+
+    context 'when a string contains a double equal signals' do
+      let(:some_string) { "==" }
+
+      it 'returns the a new value with no equal' do
+        is_expected.to eq('ORD61ORD61')
+      end
+    end
+
+    context 'when a string contains a spaceship operator' do
+      let(:some_string) { "<=>" }
+
+      it 'returns the a new value with no nave spaceship' do
+        is_expected.to eq('ORD60ORD61ORD62')
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a method name has a special char, then the method name's special char will covert to 'ORD' + ordinal.

**For example:** the method name `create!` will be `createORD33`