### PR TITLE
  [TECH] Drops support for ruby 2.2 and ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2
-  - 2.3
   - 2.4
   - 2.5
   - 2.6


### PR DESCRIPTION
After that we can update rake development dependency (https://github.com/VAGAScom/protoboard/pull/13)